### PR TITLE
Fix issue with seeds not keeping their ahentafel numbers

### DIFF
--- a/kgenealogic/cluster.py
+++ b/kgenealogic/cluster.py
@@ -236,7 +236,6 @@ def recursive_cluster(kits, tree, graph, source_neg):
             .fillna('')
             .astype(str)
         )
-        #result.label.mask(result.kit.isin(flat_seeds.kit), flat_seeds.label, inplace=True)
         result['confidence'] = result.kit.map(clusters.confidence)
         result['ahnentafel'] = np.select(
             [result.label=='P', result.label=='M'],
@@ -258,7 +257,8 @@ def recursive_cluster(kits, tree, graph, source_neg):
             result_branches.append(branch)
         result = pd.concat(result_branches, ignore_index=True)
     else:
-        result['ahnentafel'] = tree.ahnentafel
+        flat_ahnentafel = flatten(tree)
+        result['ahnentafel'] = result.kit.map(flat_ahnentafel).fillna(tree.ahnentafel)
 
     return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kgenealogic"
-version = "0.2.1"
+version = "0.2.2"
 description = "Genetic genealogy tool for tree structure inference"
 authors = ["John Wilmes <jw@johnwilmes.name>"]
 license = "MIT"


### PR DESCRIPTION
When the graph is empty, we exit early without copying ahnentafel numbers from isolated seeds deeper in the tree. This patch keeps their ahnentafel numbers